### PR TITLE
place pixel at base 

### DIFF
--- a/scss/core/base/_main.scss
+++ b/scss/core/base/_main.scss
@@ -2,7 +2,7 @@
     $MAIN
 \*------------------------------------*/
 html{
-    font-size:#{($base-font-size/16px)*100%};
+    font-size:#{$base-font-size};
     min-height:100%;
 }
 

--- a/scss/core/base/_main.scss
+++ b/scss/core/base/_main.scss
@@ -2,7 +2,7 @@
     $MAIN
 \*------------------------------------*/
 html{
-    font-size:#{$base-font-size};
+    font-size: $base-font-size;
     min-height:100%;
 }
 


### PR DESCRIPTION
I did this to ensure that the the calculation works correctly on chrome for smaller font sizes. 

The issue can be replicated by setting $base-font-size: 14px;

Therefore you end up with a 87.5% base font size.

Now test on a unordered list a before icon with a em value of anything bellow .5rem/.5em.

The result should be two different font sizes if you toggle between pixel and rem.