### PR TITLE
Inuit - improvement to f8 pixel calculator

### DIFF
--- a/scss/core/utilities/mixins/_px-and-rem.scss
+++ b/scss/core/utilities/mixins/_px-and-rem.scss
@@ -48,6 +48,8 @@
       $output: join(0, 0);
     } @else if unitless($val) {
       $output: join($val * $fs-base, $val + rem);
+    } @else if str-index(''+$val, 'px') != '' {
+      $output: join($val, $val/$fs-base + rem);
     } @else {
       $output: join($val, $val);
     }

--- a/scss/core/utilities/mixins/_px-and-rem.scss
+++ b/scss/core/utilities/mixins/_px-and-rem.scss
@@ -35,6 +35,19 @@
 //  padding: 1rem 2% 1.5em;
 // }
 
+// Example 3:
+//
+// $fs-base: 16px;
+//
+// .padding { @include px-and-rem(padding, 16px);}
+//
+// becomes
+//
+// .padding {
+//  padding: 16px;
+//  padding: 1rem;
+// }
+
 @function fix8_get_px_and_rem_val($val) {
   $output: ();
 
@@ -49,7 +62,7 @@
     } @else if unitless($val) {
       $output: join($val * $fs-base, $val + rem);
     } @else if str-index(''+$val, 'px') != '' {
-      $output: join($val, $val/$fs-base + rem);
+      $output: join($val, $val / $fs-base + rem);
     } @else {
       $output: join($val, $val);
     }


### PR DESCRIPTION
Fix the px and rem calculator by adding the functionality

```scss
// assume base font is 16px
.t {
@include px-and-rem(padding,  16px);
}
```
```css
.t {
padding: 16px;
padding: 1rem;
}
```
pen here => http://codepen.io/dewwwald/pen/QNBmrb